### PR TITLE
Resolve path with tag resolver

### DIFF
--- a/internal/app/vault_raft_snapshot_agent/config/rattlesnake.go
+++ b/internal/app/vault_raft_snapshot_agent/config/rattlesnake.go
@@ -77,7 +77,7 @@ func (r rattlesnake) Unmarshal(config interface{}) error {
 		return fmt.Errorf("could not set configuration's default-values: %s", err)
 	}
 
-	pathResolver := NewPathResolver(filepath.Dir(r.ConfigFileUsed()))
+	pathResolver := newPathResolver(filepath.Dir(r.ConfigFileUsed()))
 	if err := pathResolver.Resolve(config); err != nil {
 		return fmt.Errorf("could not resolve relative paths in configuration: %s", err)
 	}

--- a/internal/app/vault_raft_snapshot_agent/config/rattlesnake_test.go
+++ b/internal/app/vault_raft_snapshot_agent/config/rattlesnake_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 type rattlesnakeConfigStub struct {
-	Path Path `default:"/test/file"`
+	Path string `default:"/test/file" resolve-path:""`
 	Url	 string `validate:"omitempty,http_url"`
 }
 
@@ -30,7 +30,7 @@ func TestUnmarshalResolvesRelativePaths(t *testing.T) {
 	err = rattlesnake.Unmarshal(&config)
 
 	assert.NoError(t, err, "Unmarshal failed unexpectedly")
-	assert.Equal(t, Path(filepath.Clean(fmt.Sprintf("%s/file.ext", wd))), config.Path)
+	assert.Equal(t, filepath.Clean(fmt.Sprintf("%s/file.ext", wd)), config.Path)
 }
 
 func TestUnmarshalSetsDefaultValues(t *testing.T) {
@@ -40,7 +40,7 @@ func TestUnmarshalSetsDefaultValues(t *testing.T) {
 	err := rattlesnake.Unmarshal(&config)
 
 	assert.NoError(t, err, "Unmarshal failed unexpectedly")
-	assert.Equal(t, Path("/test/file"), config.Path)
+	assert.Equal(t, "/test/file", config.Path)
 }
 
 func TestUnmarshalValidatesValues(t *testing.T) {

--- a/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag.go
+++ b/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag.go
@@ -1,0 +1,86 @@
+package config
+
+import (
+	"errors"
+	"path/filepath"
+	"reflect"
+	"strings"
+)
+
+const (
+	tagFieldName = "resolve-path"
+)
+
+var (
+	ErrorInvalidType error = errors.New("subject must be a struct passed by pointer")
+)
+
+type resolver struct {
+	baseDir string
+}
+
+func NewPathResolver(baseDir string) resolver {
+	return resolver{baseDir}
+}
+
+func (r resolver) Resolve(subject interface{}) error {
+	if reflect.TypeOf(subject).Kind() != reflect.Ptr {
+		return ErrorInvalidType
+	}
+
+	s := reflect.ValueOf(subject).Elem()
+
+	return r.resolve(s)
+}
+
+func (r resolver) resolve(value reflect.Value) error {
+	t := value.Type()
+
+	if t.Kind() != reflect.Struct {
+		return ErrorInvalidType
+	}
+
+	for i := 0; i < t.NumField(); i++ {
+		f := value.Field(i)
+
+		if !f.CanSet() {
+			continue
+		}
+
+		if f.Kind() == reflect.Ptr {
+			f = f.Elem()
+		}
+
+		if f.Kind() == reflect.Struct {
+			if err := r.resolve(f); err != nil {
+				return err
+			}
+		}
+
+		if f.Kind() != reflect.String || f.String() == "" {
+			continue
+		}
+
+		if baseDir, present := t.Field(i).Tag.Lookup(tagFieldName); present {
+			if err := r.resolvePath(f, baseDir); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (r resolver) resolvePath(field reflect.Value, baseDir string) error {
+	path := field.String()
+	if baseDir == "" {
+		baseDir = r.baseDir
+	}
+
+	if !filepath.IsAbs(path) && !strings.HasPrefix(path, "/") {
+		path = filepath.Join(baseDir, path)
+		field.Set(reflect.ValueOf(path).Convert(field.Type()))
+	}
+
+	return nil
+}

--- a/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag.go
+++ b/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag.go
@@ -12,7 +12,7 @@ const (
 )
 
 var (
-	ErrorInvalidType error = errors.New("subject must be a struct passed by pointer")
+	errorInvalidType error = errors.New("subject must be a struct passed by pointer")
 )
 
 type pathResolver struct {
@@ -25,7 +25,7 @@ func newPathResolver(baseDir string) pathResolver {
 
 func (r pathResolver) Resolve(subject interface{}) error {
 	if reflect.TypeOf(subject).Kind() != reflect.Ptr {
-		return ErrorInvalidType
+		return errorInvalidType
 	}
 
 	s := reflect.ValueOf(subject).Elem()
@@ -37,7 +37,7 @@ func (r pathResolver) resolve(value reflect.Value) error {
 	t := value.Type()
 
 	if t.Kind() != reflect.Struct {
-		return ErrorInvalidType
+		return errorInvalidType
 	}
 
 	for i := 0; i < t.NumField(); i++ {

--- a/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag.go
+++ b/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag.go
@@ -19,7 +19,7 @@ type resolver struct {
 	baseDir string
 }
 
-func NewPathResolver(baseDir string) resolver {
+func newPathResolver(baseDir string) resolver {
 	return resolver{baseDir}
 }
 

--- a/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag.go
+++ b/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag.go
@@ -15,15 +15,15 @@ var (
 	ErrorInvalidType error = errors.New("subject must be a struct passed by pointer")
 )
 
-type resolver struct {
+type pathResolver struct {
 	baseDir string
 }
 
-func newPathResolver(baseDir string) resolver {
-	return resolver{baseDir}
+func newPathResolver(baseDir string) pathResolver {
+	return pathResolver{baseDir}
 }
 
-func (r resolver) Resolve(subject interface{}) error {
+func (r pathResolver) Resolve(subject interface{}) error {
 	if reflect.TypeOf(subject).Kind() != reflect.Ptr {
 		return ErrorInvalidType
 	}
@@ -33,7 +33,7 @@ func (r resolver) Resolve(subject interface{}) error {
 	return r.resolve(s)
 }
 
-func (r resolver) resolve(value reflect.Value) error {
+func (r pathResolver) resolve(value reflect.Value) error {
 	t := value.Type()
 
 	if t.Kind() != reflect.Struct {
@@ -71,7 +71,7 @@ func (r resolver) resolve(value reflect.Value) error {
 	return nil
 }
 
-func (r resolver) resolvePath(field reflect.Value, baseDir string) error {
+func (r pathResolver) resolvePath(field reflect.Value, baseDir string) error {
 	path := field.String()
 	if baseDir == "" {
 		baseDir = r.baseDir

--- a/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag_test.go
+++ b/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolvesRelativePaths(t *testing.T) {
+	var test struct {
+		Path      string `resolve-path:""`
+		FixedPath string `resolve-path:"/tmp/"`
+		Other     string
+		AbsolutePath string `resolve-path:""`
+	}
+	test.Path = "./relative"
+	test.FixedPath = "./fixed"
+	test.Other = "./other"
+	test.AbsolutePath = "/test/abs"
+
+	dir := t.TempDir()
+	resolver := NewPathResolver(dir)
+	err := resolver.Resolve(&test)
+
+	assert.NoError(t, err, "resolver.resolve failed unexepectedly")
+
+	assert.Equal(t, filepath.Clean(fmt.Sprintf("%s/relative", dir)), test.Path)
+	assert.Equal(t, filepath.Clean("/tmp/fixed"), test.FixedPath)
+	assert.Equal(t, "/test/abs", test.AbsolutePath)
+	assert.Equal(t, "./other", test.Other)
+}
+
+func TestResolvesRecursively(t *testing.T) {
+	type inner struct {
+		Path string `resolve-path:""`
+	}
+
+	innerPtr := inner{"./innerPtr"}
+
+	var outer struct {
+		Inner inner
+		InnerPtr *inner
+	}
+	outer.Inner.Path = "./inner"
+	outer.InnerPtr = &innerPtr
+
+	dir := t.TempDir()
+	resolver := NewPathResolver(dir)
+	err := resolver.Resolve(&outer)
+
+	assert.NoError(t, err, "resolver.resolve failed unexepectedly")
+
+	assert.Equal(t, filepath.Clean(fmt.Sprintf("%s/inner", dir)), outer.Inner.Path)
+	assert.Equal(t, filepath.Clean(fmt.Sprintf("%s/innerPtr", dir)), innerPtr.Path)
+
+}

--- a/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag_test.go
+++ b/internal/app/vault_raft_snapshot_agent/config/resolve-path-tag_test.go
@@ -10,9 +10,9 @@ import (
 
 func TestResolvesRelativePaths(t *testing.T) {
 	var test struct {
-		Path      string `resolve-path:""`
-		FixedPath string `resolve-path:"/tmp/"`
-		Other     string
+		Path         string `resolve-path:""`
+		FixedPath    string `resolve-path:"/tmp/"`
+		Other        string
 		AbsolutePath string `resolve-path:""`
 	}
 	test.Path = "./relative"
@@ -21,7 +21,7 @@ func TestResolvesRelativePaths(t *testing.T) {
 	test.AbsolutePath = "/test/abs"
 
 	dir := t.TempDir()
-	resolver := NewPathResolver(dir)
+	resolver := newPathResolver(dir)
 	err := resolver.Resolve(&test)
 
 	assert.NoError(t, err, "resolver.resolve failed unexepectedly")
@@ -40,14 +40,14 @@ func TestResolvesRecursively(t *testing.T) {
 	innerPtr := inner{"./innerPtr"}
 
 	var outer struct {
-		Inner inner
+		Inner    inner
 		InnerPtr *inner
 	}
 	outer.Inner.Path = "./inner"
 	outer.InnerPtr = &innerPtr
 
 	dir := t.TempDir()
-	resolver := NewPathResolver(dir)
+	resolver := newPathResolver(dir)
 	err := resolver.Resolve(&outer)
 
 	assert.NoError(t, err, "resolver.resolve failed unexepectedly")

--- a/internal/app/vault_raft_snapshot_agent/snapshotter_config_test.go
+++ b/internal/app/vault_raft_snapshot_agent/snapshotter_config_test.go
@@ -30,7 +30,7 @@ func defaultJwtPath(def string) string {
 	return "/var/run/secrets/kubernetes.io/serviceaccount/token"
 }
 
-func relativeTo(configFile string, file string) config.Path {
+func relativeTo(configFile string, file string) string {
 	if !filepath.IsAbs(file) && !strings.HasPrefix(file, "/") {
 		file = filepath.Join(filepath.Dir(configFile), file)
 	}
@@ -40,7 +40,7 @@ func relativeTo(configFile string, file string) config.Path {
 		file = filepath.Clean(file)
 	}
 
-	return config.Path(file)
+	return file
 }
 
 func TestReadCompleteConfig(t *testing.T) {

--- a/internal/app/vault_raft_snapshot_agent/vault/auth/kubernetes.go
+++ b/internal/app/vault_raft_snapshot_agent/vault/auth/kubernetes.go
@@ -1,14 +1,13 @@
 package auth
 
 import (
-	"github.com/Argelbargel/vault-raft-snapshot-agent/internal/app/vault_raft_snapshot_agent/config"
 	"github.com/hashicorp/vault/api/auth/kubernetes"
 )
 
 type KubernetesAuthConfig struct {
-	Path    string      `default:"kubernetes"`
-	Role    string      `validate:"required_if=Empty false"`
-	JWTPath config.Path `default:"/var/run/secrets/kubernetes.io/serviceaccount/token" validate:"omitempty,file,required_if=Empty false"`
+	Path    string `default:"kubernetes"`
+	Role    string `validate:"required_if=Empty false"`
+	JWTPath string `default:"/var/run/secrets/kubernetes.io/serviceaccount/token" resolve-path:"" validate:"omitempty,file,required_if=Empty false"`
 	Empty   bool
 }
 

--- a/internal/app/vault_raft_snapshot_agent/vault/auth/kubernetes_test.go
+++ b/internal/app/vault_raft_snapshot_agent/vault/auth/kubernetes_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Argelbargel/vault-raft-snapshot-agent/internal/app/vault_raft_snapshot_agent/config"
 	"github.com/Argelbargel/vault-raft-snapshot-agent/internal/app/vault_raft_snapshot_agent/test"
 
 	"github.com/hashicorp/vault/api/auth/kubernetes"
@@ -15,9 +14,9 @@ import (
 func TestCreateKubernetesAuth(t *testing.T) {
 	jwtPath := fmt.Sprintf("%s/jwt", t.TempDir())
 	config := KubernetesAuthConfig{
-		Role: "test-role",
-		JWTPath: config.Path(jwtPath),
-		Path: "test-path",
+		Role:    "test-role",
+		JWTPath: jwtPath,
+		Path:    "test-path",
 	}
 
 	err := test.WriteFile(t, jwtPath, "test")
@@ -26,7 +25,7 @@ func TestCreateKubernetesAuth(t *testing.T) {
 	expectedAuthMethod, err := kubernetes.NewKubernetesAuth(
 		config.Role,
 		kubernetes.WithMountPath(config.Path),
-		kubernetes.WithServiceAccountTokenPath(string(config.JWTPath)),
+		kubernetes.WithServiceAccountTokenPath(config.JWTPath),
 	)
 	assert.NoError(t, err, "NewKubernetesAuth failed unexpectedly")
 


### PR DESCRIPTION
Instead of using a viper/mapstructure-decode hook we now can tag configuration-properties allowing path relative to the config-file with a go-struct-tag