### PR TITLE
Refactor storage to properly support dynamic configuration; to pick u…

### DIFF
--- a/internal/agent/snapshot-agent.go
+++ b/internal/agent/snapshot-agent.go
@@ -107,12 +107,7 @@ func (a *SnapshotAgent) reconfigure(ctx context.Context, config SnapshotAgentCon
 		return err
 	}
 
-	manager, err := storage.CreateManager(ctx, config.Snapshots.Storages)
-	if err != nil {
-		return err
-	}
-
-	a.update(ctx, client, manager, config.Snapshots.StorageConfigDefaults)
+	a.update(ctx, client, storage.CreateManager(config.Snapshots.Storages), config.Snapshots.StorageConfigDefaults)
 	return nil
 }
 

--- a/internal/agent/storage/config.go
+++ b/internal/agent/storage/config.go
@@ -13,7 +13,7 @@ type StoragesConfig struct {
 	Swift SwiftStorageConfig `default:"{\"Empty\": true}"`
 }
 
-// StorageConfigDefaults specified the default values of storageConfig for all controllers
+// StorageConfigDefaults specified the default values of storageConfig for all factories
 type StorageConfigDefaults struct {
 	Frequency       time.Duration `default:"1h"`
 	Retain          int
@@ -34,42 +34,42 @@ type storageConfig struct {
 	TimestampFormat string
 }
 
-func (c storageConfig) FrequencyOrDefault(defaults StorageConfigDefaults) time.Duration {
+func (c storageConfig) frequencyOrDefault(defaults StorageConfigDefaults) time.Duration {
 	if c.Frequency > 0 {
 		return c.Frequency
 	}
 	return defaults.Frequency
 }
 
-func (c storageConfig) RetainOrDefault(defaults StorageConfigDefaults) int {
+func (c storageConfig) retainOrDefault(defaults StorageConfigDefaults) int {
 	if c.Retain >= 0 {
 		return c.Retain
 	}
 	return defaults.Retain
 }
 
-func (c storageConfig) TimeoutOrDefault(defaults StorageConfigDefaults) time.Duration {
+func (c storageConfig) timeoutOrDefault(defaults StorageConfigDefaults) time.Duration {
 	if c.Timeout > 0 {
 		return c.Timeout
 	}
 	return defaults.Timeout
 }
 
-func (c storageConfig) NamePrefixOrDefault(defaults StorageConfigDefaults) string {
+func (c storageConfig) namePrefixOrDefault(defaults StorageConfigDefaults) string {
 	if c.NamePrefix != "" {
 		return c.NamePrefix
 	}
 	return defaults.NamePrefix
 }
 
-func (c storageConfig) NameSuffixOrDefault(defaults StorageConfigDefaults) string {
+func (c storageConfig) nameSuffixOrDefault(defaults StorageConfigDefaults) string {
 	if c.NameSuffix != "" {
 		return c.NameSuffix
 	}
 	return defaults.NameSuffix
 }
 
-func (c storageConfig) TimestampFormatOrDefault(defaults StorageConfigDefaults) string {
+func (c storageConfig) timestampFormatOrDefault(defaults StorageConfigDefaults) string {
 	if c.TimestampFormat != "" {
 		return c.TimestampFormat
 	}

--- a/internal/agent/storage/controller.go
+++ b/internal/agent/storage/controller.go
@@ -10,76 +10,70 @@ import (
 	"time"
 )
 
-// storageControllerImpl implements storageController.
+// storageControllerImpl implements StorageController.
 // Access to the storage-location is delegated to the given storage.
 // Options like upload-frequency, snapshot-naming are configured by the given storageControllerConfig.
 type storageControllerImpl[S any] struct {
-	config      storageControllerConfig
-	destination string
-	storage     storage[S]
-	lastUpload  time.Time
+	config     storageControllerConfig
+	storage    storage[S]
+	lastUpload time.Time
 }
 
 // storage defines the interface used by storageControllerImpl to access a storage-location
 type storage[S any] interface {
-	UploadSnapshot(ctx context.Context, name string, data io.Reader) error
-	DeleteSnapshot(ctx context.Context, snapshot S) error
-	ListSnapshots(ctx context.Context, prefix string, suffix string) ([]S, error)
-	GetLastModifiedTime(snapshot S) time.Time
+	uploadSnapshot(ctx context.Context, name string, data io.Reader) error
+	deleteSnapshot(ctx context.Context, snapshot S) error
+	listSnapshots(ctx context.Context, prefix string, suffix string) ([]S, error)
+	getLastModifiedTime(snapshot S) time.Time
 }
 
 // storageControllerConfig defines the interface used by storageControllerImpl to determine its required configuration
 // options either from the storageConfig for the controlled storage or the global StorageConfigDefaults for all storages
 type storageControllerConfig interface {
-	FrequencyOrDefault(StorageConfigDefaults) time.Duration
-	RetainOrDefault(StorageConfigDefaults) int
-	TimeoutOrDefault(StorageConfigDefaults) time.Duration
-	NamePrefixOrDefault(StorageConfigDefaults) string
-	NameSuffixOrDefault(StorageConfigDefaults) string
-	TimestampFormatOrDefault(StorageConfigDefaults) string
+	frequencyOrDefault(StorageConfigDefaults) time.Duration
+	retainOrDefault(StorageConfigDefaults) int
+	timeoutOrDefault(StorageConfigDefaults) time.Duration
+	namePrefixOrDefault(StorageConfigDefaults) string
+	nameSuffixOrDefault(StorageConfigDefaults) string
+	timestampFormatOrDefault(StorageConfigDefaults) string
 }
 
 // newStorageController creates a new storageControllerImpl uploading snapshots to the
 // given storage configured according to the given storageControllerConfig
-func newStorageController[S any](config storageControllerConfig, destination string, storage storage[S]) *storageControllerImpl[S] {
+func newStorageController[S any](config storageControllerConfig, storage storage[S]) *storageControllerImpl[S] {
 	return &storageControllerImpl[S]{
-		config:      config,
-		destination: destination,
-		storage:     storage,
+		config:  config,
+		storage: storage,
 	}
 }
 
-func (u *storageControllerImpl[S]) Destination() string {
-	return u.destination
-}
-
-func (u *storageControllerImpl[S]) ScheduleSnapshot(ctx context.Context, lastSnapshotTime time.Time, defaults StorageConfigDefaults) time.Time {
+func (u *storageControllerImpl[S]) ScheduleSnapshot(ctx context.Context, lastSnapshotTime time.Time, defaults StorageConfigDefaults) (time.Time, error) {
 	if err := u.ensureLastUploadTime(ctx, lastSnapshotTime, defaults); err != nil {
-		logging.Warn("Could not schedule snapshot", "destination", u.destination, "error", err)
-		return time.Time{}
+		return time.Time{}, err
 	}
 
-	return u.lastUpload.Add(u.config.FrequencyOrDefault(defaults))
+	return u.lastUpload.Add(u.config.frequencyOrDefault(defaults)), nil
 }
 
 func (u *storageControllerImpl[S]) UploadSnapshot(ctx context.Context, snapshot io.Reader, timestamp time.Time, defaults StorageConfigDefaults) (bool, time.Time, error) {
-	frequency := u.config.FrequencyOrDefault(defaults)
+	frequency := u.config.frequencyOrDefault(defaults)
 
 	if timestamp.Before(u.lastUpload.Add(frequency)) {
-		return false, u.ScheduleSnapshot(ctx, timestamp, defaults), nil
+		nextSnapshot, err := u.ScheduleSnapshot(ctx, timestamp, defaults)
+		return false, nextSnapshot, err
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, u.config.TimeoutOrDefault(defaults))
+	ctx, cancel := context.WithTimeout(ctx, u.config.timeoutOrDefault(defaults))
 	defer cancel()
 
 	nextSnapshot := timestamp.Add(frequency)
 
-	prefix := u.config.NamePrefixOrDefault(defaults)
-	suffix := u.config.NameSuffixOrDefault(defaults)
-	ts := timestamp.Format(u.config.TimestampFormatOrDefault(defaults))
+	prefix := u.config.namePrefixOrDefault(defaults)
+	suffix := u.config.nameSuffixOrDefault(defaults)
+	ts := timestamp.Format(u.config.timestampFormatOrDefault(defaults))
 	snapshotName := strings.Join([]string{prefix, ts, suffix}, "")
 
-	if err := u.storage.UploadSnapshot(ctx, snapshotName, snapshot); err != nil {
+	if err := u.storage.uploadSnapshot(ctx, snapshotName, snapshot); err != nil {
 		return false, nextSnapshot, err
 	}
 
@@ -89,15 +83,15 @@ func (u *storageControllerImpl[S]) UploadSnapshot(ctx context.Context, snapshot 
 }
 
 func (u *storageControllerImpl[S]) DeleteObsoleteSnapshots(ctx context.Context, defaults StorageConfigDefaults) (int, error) {
-	retain := u.config.RetainOrDefault(defaults)
+	retain := u.config.retainOrDefault(defaults)
 	if retain < 1 {
 		return 0, nil
 	}
 
-	ctx, cancel := context.WithTimeout(ctx, u.config.TimeoutOrDefault(defaults))
+	ctx, cancel := context.WithTimeout(ctx, u.config.timeoutOrDefault(defaults))
 	defer cancel()
 
-	snapshots, err := u.listSnapshots(ctx, u.config.NamePrefixOrDefault(defaults), u.config.NameSuffixOrDefault(defaults))
+	snapshots, err := u.listSnapshots(ctx, u.config.namePrefixOrDefault(defaults), u.config.nameSuffixOrDefault(defaults))
 	if err != nil {
 		return 0, err
 	}
@@ -108,8 +102,8 @@ func (u *storageControllerImpl[S]) DeleteObsoleteSnapshots(ctx context.Context, 
 
 	deleted := 0
 	for _, s := range snapshots[retain:] {
-		if err := u.storage.DeleteSnapshot(ctx, s); err != nil {
-			logging.Warn("Could not delete snapshot", "snapshot", s, "destination", u.destination, "error", err)
+		if err := u.storage.deleteSnapshot(ctx, s); err != nil {
+			logging.Warn("Could not delete snapshot", "snapshot", s, "error", err)
 		} else {
 			deleted++
 		}
@@ -119,13 +113,13 @@ func (u *storageControllerImpl[S]) DeleteObsoleteSnapshots(ctx context.Context, 
 }
 
 func (u *storageControllerImpl[S]) listSnapshots(ctx context.Context, prefix string, suffix string) ([]S, error) {
-	snapshots, err := u.storage.ListSnapshots(ctx, prefix, suffix)
+	snapshots, err := u.storage.listSnapshots(ctx, prefix, suffix)
 	if err != nil {
 		return nil, err
 	}
 
 	slices.SortFunc(snapshots, func(a, b S) int {
-		return u.storage.GetLastModifiedTime(a).Compare(u.storage.GetLastModifiedTime(b))
+		return u.storage.getLastModifiedTime(a).Compare(u.storage.getLastModifiedTime(b))
 	})
 
 	return snapshots, nil
@@ -147,10 +141,10 @@ func (u *storageControllerImpl[S]) ensureLastUploadTime(ctx context.Context, las
 }
 
 func (u *storageControllerImpl[S]) getLastModificationTime(ctx context.Context, defaults StorageConfigDefaults) (time.Time, error) {
-	ctx, cancel := context.WithTimeout(ctx, u.config.TimeoutOrDefault(defaults))
+	ctx, cancel := context.WithTimeout(ctx, u.config.timeoutOrDefault(defaults))
 	defer cancel()
 
-	snapshots, err := u.storage.ListSnapshots(ctx, u.config.NamePrefixOrDefault(defaults), u.config.NameSuffixOrDefault(defaults))
+	snapshots, err := u.storage.listSnapshots(ctx, u.config.namePrefixOrDefault(defaults), u.config.nameSuffixOrDefault(defaults))
 	if err != nil {
 		return u.lastUpload, err
 	}
@@ -159,6 +153,6 @@ func (u *storageControllerImpl[S]) getLastModificationTime(ctx context.Context, 
 		return u.lastUpload, errors.New("storage does not contain any snapshots")
 	}
 
-	u.lastUpload = u.storage.GetLastModifiedTime(snapshots[0])
+	u.lastUpload = u.storage.getLastModifiedTime(snapshots[0])
 	return u.lastUpload, nil
 }


### PR DESCRIPTION
Refactor storage to properly support dynamic configuration; to pick up changes of env-vars or files, we need to recreate the storage-clients on every interval…p changes of env-vars or files, we need to recreate the storage-clients on every interval