### PR TITLE
Fix typo that is breaks Azure authentication

### DIFF
--- a/internal/agent/storage/azure.go
+++ b/internal/agent/storage/azure.go
@@ -47,7 +47,7 @@ func createAzBlobClient(config AzureStorageConfig) (*azblob.Client, error) {
 		return nil, err
 	}
 
-	accountKey, err := config.AccountName.Resolve(true)
+	accountKey, err := config.AccountKey.Resolve(true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR fixes #24 

Incorrectly calling `config.AccountName.Resolve(true)`, instead of `config.AccountKey.Resolve(true)` causes the Azure API call to fail.