### PR TITLE
Make sure the default config file name is consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Agent into your cluster.
 You can run the agent with the supplied container-image, e.g. via docker:
 
 ```
-docker run -v <path to snapshot.json>:/etc/vault.d/snapshot.json" ghcr.io/argelbargel/vault-raft-snapshot-agent:latest
+docker run -v <path to snapshots.json>:/etc/vault.d/snapshots.json" ghcr.io/argelbargel/vault-raft-snapshot-agent:latest
 ```
 
 ### systemd-service
@@ -41,7 +41,7 @@ Description="An Open Source Snapshot Service for Raft"
 Documentation=https://github.com/Argelbargel/vault-raft-snapshot-agent/
 Requires=network-online.target
 After=network-online.target
-ConditionFileNotEmpty=/etc/vault.d/snapshot.json
+ConditionFileNotEmpty=/etc/vault.d/snapshots.json
 
 [Service]
 Type=simple
@@ -57,7 +57,7 @@ LimitNOFILE=65536
 WantedBy=multi-user.target
 ```
 
-Your configuration is assumed to exist at `/etc/vault.d/snapshot.json` and the actual daemon binary
+Your configuration is assumed to exist at `/etc/vault.d/snapshots.json` and the actual daemon binary
 at `/usr/local/bin/vault-raft-snapshot-agent`.
 
 Then just run:

--- a/cmd/vault-raft-snapshot-agent/main.go
+++ b/cmd/vault-raft-snapshot-agent/main.go
@@ -27,8 +27,8 @@ The options are:
 		Specifies the output to log to (default: stderr)
 
 If no config file is explicitly specified, the program looks for configuration-files
-with the name `snapshot` and the extensions supported by [viper]
-in the current working directory or in /etc/vault.d/snapshots.
+with the name `snapshots` and the extensions supported by [viper]
+in the current working directory or in /etc/vault.d/.
 
 For details on how to configure the program see the [README]
 


### PR DESCRIPTION
According to https://github.com/Argelbargel/vault-raft-snapshot-agent/blob/c7e6af1e4a0df979caef7a3b9a7043de70132773/cmd/vault-raft-snapshot-agent/main.go#L57
we are looking for a file named `snapshots` (plural).

This PR updates the relevant docs to maintain consistency, as `snapshot` (singular) is mentioned several times and can lead to confusion.
